### PR TITLE
Add Article model and association to Post

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,5 @@
+class Article < ApplicationRecord
+  validates :content, presence: true
+
+  belongs_to :post
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,5 @@
 class Post < ApplicationRecord
   validates :published_at, :title, presence: true
+
+  has_one :article
 end

--- a/db/migrate/20201012033452_create_articles.rb
+++ b/db/migrate/20201012033452_create_articles.rb
@@ -1,0 +1,10 @@
+class CreateArticles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :articles do |t|
+      t.belongs_to :post
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_02_014109) do
+ActiveRecord::Schema.define(version: 2020_10_12_033452) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "articles", force: :cascade do |t|
+    t.bigint "post_id"
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_articles_on_post_id"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.datetime "published_at", default: -> { "now()" }, null: false
@@ -21,4 +30,5 @@ ActiveRecord::Schema.define(version: 2020_10_02_014109) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
+
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  sequence(:title) { |n| "Blog ##{n}" }
+
+  factory :article do
+    association(:post)
+
+    content { "This is an article for a blog post!" }
+  end
+
+  factory :post do
+    image_url { "www.someimage.com" }
+    published_at { 1.month.from_now }
+    title
+  end
+end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+FactoryBot.factories.map(&:name).each do |factory_name|
+  describe "#{factory_name} factory" do
+    it "is valid" do
+      factory = build(factory_name)
+
+      if factory.respond_to?(:valid?)
+        expect(factory).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe Article, type: :model do
+  describe "validations" do
+    it { is_expected.to belong_to(:post) }
+    it { is_expected.to validate_presence_of(:content) }
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,7 +1,8 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Post, type: :model do
   describe "validations" do
+    it { is_expected.to have_one(:article) }
     it { is_expected.to validate_presence_of(:published_at) }
     it { is_expected.to validate_presence_of(:title) }
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,6 +62,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
This commit adds the Article model, which belongs_to a Post.

In order to facilitate testing, factories were added.  Unfortunately,
there were [unrecognized factories](https://github.com/thoughtbot/factory_bot_rails/issues/341), and it was necessary to add
`config.include FactoryBot::Syntax::Methods` to my `rails_helper`
config.