### PR TITLE
Add Seed Data

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,5 @@
 class Article < ApplicationRecord
   validates :content, presence: true
 
-  belongs_to :post
+  belongs_to :post, required: false
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
   validates :name, presence: true
 
-  belongs_to :post
+  belongs_to :post, required: false
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
-  validates :published_at, :title, presence: true
+  validates :title, presence: true
 
-  has_one :article
-  has_many :categories
   has_and_belongs_to_many :tags
+  has_many :categories
+  has_one :article
 end

--- a/db/migrate/20201014211735_create_categories_posts_join_table.rb
+++ b/db/migrate/20201014211735_create_categories_posts_join_table.rb
@@ -1,0 +1,10 @@
+class CreateCategoriesPostsJoinTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :categories_posts, id: false do |t|
+      t.bigint :category_id
+      t.bigint :post_id
+    end
+
+    add_index :categories_posts, [:category_id, :post_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_12_165117) do
+ActiveRecord::Schema.define(version: 2020_10_14_211735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,12 @@ ActiveRecord::Schema.define(version: 2020_10_12_165117) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["post_id"], name: "index_categories_on_post_id"
+  end
+
+  create_table "categories_posts", id: false, force: :cascade do |t|
+    t.bigint "category_id"
+    t.bigint "post_id"
+    t.index ["category_id", "post_id"], name: "index_categories_posts_on_category_id_and_post_id", unique: true
   end
 
   create_table "posts", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,47 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# create 5 articles
+article1 = Article.create!(content: "It's important to me that you're happy. Maybe we got a few little happy bushes here, just covered with snow. It's all a game of angles. Anytime you learn something your time and energy are not wasted. You can do anything your heart can imagine.
+
+Do an almighty painting with us. We tell people sometimes: we're like drug dealers, come into town and get everybody absolutely addicted to painting. It doesn't take much to get you addicted. I guess that would be considered a UFO. A big cotton ball in the sky. Automatically, all of these beautiful, beautiful things will happen.")
+
+article2 = Article.create!(content: "Steve wants reflections, so let's give him reflections. A big strong tree needs big strong roots. Imagination is the key to painting.
+
+We'll put some happy little leaves here and there. Nothing's gonna make your husband or wife madder than coming home and having a snow-covered dinner. Let's get crazy. Let's do it again then, what the heck. Now it's beginning to make a little sense. There are no limits in this world.")
+
+article3 = Article.create!(content: "This is an example of what you can do with just a few things, a little imagination and a happy dream in your heart. How do you make a round circle with a square knife? That's your challenge for the day. We can fix anything. Let's go up in here, and start having some fun We'll put all the little clouds in and let them dance around and have fun.
+
+So often we avoid running water, and running water is a lot of fun. Making all those little fluffies that live in the clouds. Let the paint work. Just go back and put one little more happy tree in there. Let's put a touch more of the magic here.")
+
+article4 = Article.create!(content: "I get carried away with this brush cleaning. Isn't that fantastic? You can just push a little tree out of your brush like that. Making all those little fluffies that live in the clouds. And just raise cain. The first step to doing anything is to believe you can do it. See it finished in your mind before you ever start. You can create anything that makes you happy.
+
+Isn't that fantastic that you can make whole mountains in minutes? Without washing the brush, I'm gonna go right into some Van Dyke Brown, some Burnt Umber, and a little bit of Sap Green. How to paint. That's easy. What to paint. That's much harder. We don't want to set these clouds on fire. We'll play with clouds today. Tree trunks grow however makes them happy.")
+
+article5 = Article.create!(content: "Maybe there's a little something happening right here. Let's build some happy little clouds up here. You can do it.
+
+This present moment is perfect simply due to the fact you're experiencing it. It's a super day, so why not make a beautiful sky? It's life. It's interesting. It's fun. There isn't a rule. You just practice and find out which way works best for you. This is your world. Let's have a happy little tree in here.")
+
+# create 3 categories
+category1 = Category.create!(name: "The Kitchen")
+category2 = Category.create!(name: "Critiques")
+category3 = Category.create!(name: "K-Culture")
+
+# create 5 tags
+tag1 = Tag.create!(name: "lecreuset")
+tag2 = Tag.create!(name: "staub")
+tag3 = Tag.create!(name: "bts")
+tag4 = Tag.create!(name: "politics")
+tag5 = Tag.create!(name: "life")
+
+# create 5 posts with article, categories, and tags
+Post.create!(title: "Post #1", article: article1, categories: [category1], tags: [tag1, tag2])
+
+Post.create!(title: "Post #2", article: article2, categories: [category1], tags: [tag1, tag2])
+
+Post.create!(title: "Post #3", article: article3, categories: [category2], tags: [tag5])
+
+Post.create!(title: "Post #4", article: article4, categories: [category2], tags: [tag4])
+
+Post.create!(title: "Post #5", article: article5, categories: [category3], tags: [tag3])

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Article, type: :model do
   describe "validations" do
-    it { is_expected.to belong_to(:post) }
     it { is_expected.to validate_presence_of(:content) }
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Category, type: :model do
   describe "validations" do
-    it { is_expected.to belong_to(:post) }
     it { is_expected.to validate_presence_of(:name) }
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2,10 +2,9 @@ require "rails_helper"
 
 RSpec.describe Post, type: :model do
   describe "validations" do
-    it { is_expected.to have_one(:article) }
-    it { is_expected.to have_many(:categories) }
     it { is_expected.to have_and_belong_to_many(:tags) }
-    it { is_expected.to validate_presence_of(:published_at) }
+    it { is_expected.to have_many(:categories) }
+    it { is_expected.to have_one(:article) }
     it { is_expected.to validate_presence_of(:title) }
   end
 end


### PR DESCRIPTION
This commit adds in some basic seed data to make development smoother.

While adding posts, it became clear that the associations between
category/post and article/post were not configured properly.  Rails 5
introduced a validation check on all `belongs_to` associations, so that
was overridden with a `required: false` inclusion. A missing join table
between category and post was also included.

Finally the presence validation on `published_at` was removed from Post,
but the default value and presence validation was left in the migration.