### PR TITLE
Copy Categories To Home Page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,11 @@
 class HomeController < ApplicationController
   def index
+    categories = Category.all
     post = Post.order("updated_at").where(featured: true).last
 
     render locals: {
-      post: post
+      post: post,
+      categories: categories
     }
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,4 +2,10 @@
 
 <%= render "posts/featured_post", post: post %>
 
+<ul>
+<% categories.each do |category| %>
+  <li><%= link_to category.name, category_path(category.id) %></li>
+<% end %>
+</ul>
+
 <%= link_to t("categories.index.heading"), categories_path %>


### PR DESCRIPTION
The intial location of the categories was for development purposes.
They should be displayed on the home page, so this commit moves them to
where they belong.