### PR TITLE
Update The Post Factory To Build Categories and Tags

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,54 +1,40 @@
 FactoryBot.define do
   factory :article do
-    association(:post)
-
     content { "This is an article for a blog post!" }
   end
 
   factory :category do
     sequence(:name) { |n| "Category #{n}" }
-
-    trait :post_with_categories do
-      transient do
-        categories_count { 1 }
-      end
-
-      after(:create) do |post, evaluator|
-        create_list(:category, evaluator.categories_count, posts: [post])
-        post.reload
-      end
-    end
   end
 
   factory :post do
+    article
+
     image_url { "www.someimage.com" }
     published_at { 1.month.from_now }
     sequence(:title) { |n| "Blog Content ##{n}" }
 
-    factory :post_with_categories do
+    factory :post_with_categories_and_tags do
       transient do
-        categories_count { 1 }
+        categories_count { 2 }
+        tags_count { 3 }
       end
 
-      after(:create) do |post, evaluator|
-        create_list(:category, evaluator.categories_count, posts: [post])
-        post.reload
+      categories do
+        Array.new(categories_count) do
+          association(:category, posts: [instance])
+        end
+      end
+
+      tags do
+        Array.new(tags_count) do
+          association(:tag, posts: [instance])
+        end
       end
     end
   end
 
   factory :tag do
     sequence(:name) { |n| "tag#{n}" }
-
-    trait :post_with_tags do
-      transient do
-        tags_count { 3 }
-      end
-
-      after(:create) do |profile, evaluator|
-        create_list(:tag, evaluator.tags_count, posts: [post])
-        profile.reload
-      end
-    end
   end
 end


### PR DESCRIPTION
This commit fixes an existing problem where the categories and tags had
to be built separately in a spec.  Now, those has_and_belongs_to_many
[associations](https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#has_and_belongs_to_many-associations) are created inside the post factory as a nested factory.