### PR TITLE
Create truncated post

### DIFF
--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -5,5 +5,5 @@
 <p><%= link_to t(".navigation.helpers.back"), categories_path %>
 
 <% posts.each do |post| %>
-  <%= render "posts/post", post: post %>
+  <%= render "posts/truncated", post: post %>
 <% end %>

--- a/app/views/posts/_truncated.html.erb
+++ b/app/views/posts/_truncated.html.erb
@@ -1,0 +1,5 @@
+<div>
+  <h2><%= link_to post.title, post_path(post) %></h2>
+  <p><%= post.published_at %></p>
+  <p><%= truncate(post.article.content, length: 200) %></p>
+</div>

--- a/app/views/posts/_truncated.html.erb
+++ b/app/views/posts/_truncated.html.erb
@@ -1,5 +1,5 @@
 <div>
   <h2><%= link_to post.title, post_path(post) %></h2>
   <p><%= post.published_at %></p>
-  <p><%= truncate(post.article.content, length: 200) %></p>
+  <p><%= truncate(post.article.content, length: 200, separator: ' ') { link_to t(".keep_reading"), post_path(post) }%></p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,3 +48,5 @@ en:
       label: "** Featured **"
     show:
       back_to_category: "Back to %{category_name}"
+    truncated:
+      keep_reading: " keep reading"

--- a/spec/system/visitor_views_blog_list_spec.rb
+++ b/spec/system/visitor_views_blog_list_spec.rb
@@ -18,19 +18,14 @@ RSpec.describe "Visitor views blog list", type: :system do
       category = create(:category)
       article1 = create(:article)
       article2 = create(:article)
-      tag1 = create(:tag)
-      tag2 = create(:tag)
-      tag3 = create(:tag)
 
       post1 = create(:post,
         categories: [category],
-        article: article1,
-        tags: [tag1])
+        article: article1)
 
       post2 = create(:post,
         categories: [category],
-        article: article2,
-        tags: [tag2, tag3])
+        article: article2)
 
       visit categories_path
       click_on category.name
@@ -40,10 +35,7 @@ RSpec.describe "Visitor views blog list", type: :system do
         name: category.name
       )
       expect(page).to have_content post1.article.content
-      expect(page).to have_content post1.tags.first.name
       expect(page).to have_content post2.article.content
-      expect(page).to have_content post2.tags.first.name
-      expect(page).to have_content post2.tags.last.name
     end
   end
 end

--- a/spec/system/visitor_views_post_spec.rb
+++ b/spec/system/visitor_views_post_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Visitor views posts", type: :system do
 
       expect(page).to have_content post.title
       expect(page).to have_content post.published_at
-      expect(page).to have_content(post.article.content.truncate(200))
+      expect(page).to have_content(post.article.content.truncate(200, separator: " ") { link_to t("posts.truncated.keep_reading"), post_path(post) })
       expect(page).not_to have_content(post.tags.first.name)
     end
   end

--- a/spec/system/visitor_views_post_spec.rb
+++ b/spec/system/visitor_views_post_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Visitor views posts", type: :system do
       expect(page).to have_content post.published_at
       expect(page).to have_content(post.article.content.truncate(200, separator: " ") { link_to t("posts.truncated.keep_reading"), post_path(post) })
       expect(page).not_to have_content(post.tags.first.name)
+      expect(page).not_to have_content(post.article.content)
     end
   end
 end

--- a/spec/system/visitor_views_post_spec.rb
+++ b/spec/system/visitor_views_post_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.describe "Visitor views featured post", type: :system do
-  context "by clicking on 'see more' link" do
-    it "shows the post" do
+RSpec.describe "Visitor views posts", type: :system do
+  context "by clicking on 'see full post' link on home" do
+    it "shows the full post" do
       category = create(:category)
       article = create(:article)
       tag = create(:tag)
@@ -21,6 +21,27 @@ RSpec.describe "Visitor views featured post", type: :system do
       expect(page).to have_content post.published_at
       expect(page).to have_content post.tags.first.name
       expect(page).to have_content post.article.content
+    end
+  end
+
+  context "by viewing post on category show page" do
+    it "shows truncated post" do
+      category = create(:category)
+      content = "It's important to me that you're happy. Maybe we got a few little happy bushes here, just covered with snow. It's all a game of angles. Anytime you learn something your time and energy are not wasted. You can do anything your heart can imagine. Do an almighty painting with us. We tell people sometimes: we're like drug dealers, come into town and get everybody absolutely addicted to painting. It doesn't take much to get you addicted. I guess that would be considered a UFO. A big cotton ball in the sky. Automatically, all of these beautiful, beautiful things will happen."
+      article = create(:article, content: content)
+      tag = create(:tag)
+
+      post = create(:post,
+        categories: [category],
+        article: article,
+        tags: [tag])
+
+      visit category_path(category)
+
+      expect(page).to have_content post.title
+      expect(page).to have_content post.published_at
+      expect(page).to have_content(post.article.content.truncate(200))
+      expect(page).not_to have_content(post.tags.first.name)
     end
   end
 end


### PR DESCRIPTION
This commit creates a partial for a truncated blog post.  These posts
will be shown on the `category/show` page.

_N.B. Follow-on work will include merging the various post types into one partial._


<details>
<summary>Screenshots</summary>

<img width="609" alt="Screen Shot 2020-10-27 at 7 18 00 AM" src="https://user-images.githubusercontent.com/7423975/97294757-cbae0200-1824-11eb-8927-97ece5331818.png">
</details>
