### PR TITLE
Update Specs To Use New Factories

### DIFF
--- a/spec/system/visitor_views_blog_list_spec.rb
+++ b/spec/system/visitor_views_blog_list_spec.rb
@@ -15,10 +15,7 @@ RSpec.describe "Visitor views blog list", type: :system do
       )
 
       expect(page).to have_content first_post.article.content
-      expect(page).to have_content first_post.tags.first.name
       expect(page).to have_content second_post.article.content
-      expect(page).to have_content second_post.tags.first.name
-      expect(page).to have_content second_post.tags.last.name
     end
   end
 end

--- a/spec/system/visitor_views_blog_list_spec.rb
+++ b/spec/system/visitor_views_blog_list_spec.rb
@@ -4,16 +4,8 @@ RSpec.describe "Visitor views blog list", type: :system do
   context "by visiting an individual category page" do
     it "shows a list of posts for that category" do
       category = create(:category)
-      article1 = create(:article)
-      article2 = create(:article)
-
-      post1 = create(:post,
-        categories: [category],
-        article: article1)
-
-      post2 = create(:post,
-        categories: [category],
-        article: article2)
+      first_post = create(:post_with_categories_and_tags, categories: [category])
+      second_post = create(:post_with_categories_and_tags, categories: [category])
 
       visit category_path(category)
 
@@ -21,8 +13,12 @@ RSpec.describe "Visitor views blog list", type: :system do
         "categories.show.page_description",
         name: category.name
       )
-      expect(page).to have_content post1.article.content
-      expect(page).to have_content post2.article.content
+
+      expect(page).to have_content first_post.article.content
+      expect(page).to have_content first_post.tags.first.name
+      expect(page).to have_content second_post.article.content
+      expect(page).to have_content second_post.tags.first.name
+      expect(page).to have_content second_post.tags.last.name
     end
   end
 end

--- a/spec/system/visitor_views_featured_post_on_home_page_spec.rb
+++ b/spec/system/visitor_views_featured_post_on_home_page_spec.rb
@@ -3,27 +3,13 @@ require "rails_helper"
 RSpec.describe "Visitor views featured post on home page", type: :system do
   context "by going to the home page" do
     it "shows featured post" do
-      category = create(:category)
-      article1 = create(:article)
-      article2 = create(:article)
-      tag1 = create(:tag)
-      tag2 = create(:tag)
-      tag3 = create(:tag)
-
-      featured_post = create(:post,
-        categories: [category],
-        article: article1,
-        tags: [tag1],
-        featured: true)
-
-      regular_post = create(:post,
-        categories: [category],
-        article: article2,
-        tags: [tag2, tag3])
+      regular_post = create(:post)
+      featured_post = create(:post, featured: true)
 
       visit root_path
 
       expect(page).to have_content featured_post.title
+      expect(page).to have_content I18n.t("posts.featured.label")
       expect(page).not_to have_content regular_post.title
     end
   end

--- a/spec/system/visitor_views_post_spec.rb
+++ b/spec/system/visitor_views_post_spec.rb
@@ -1,17 +1,9 @@
 require "rails_helper"
 
-RSpec.describe "Visitor views posts", type: :system do
-  context "by clicking on 'see full post' link on home" do
-    it "shows the full post" do
-      category = create(:category)
-      article = create(:article)
-      tag = create(:tag)
-
-      post = create(:post,
-        categories: [category],
-        article: article,
-        tags: [tag],
-        featured: true)
+RSpec.describe "Visitor views full posts", type: :system do
+  context "by clicking on 'see full post' link on home page" do
+    it "shows the full featured post" do
+      post = create(:post_with_categories_and_tags, featured: true)
 
       visit root_path
 
@@ -19,6 +11,7 @@ RSpec.describe "Visitor views posts", type: :system do
 
       expect(page).to have_content post.title
       expect(page).to have_content post.published_at
+      expect(page).to have_content I18n.t("posts.featured.label")
       expect(page).to have_content post.tags.first.name
       expect(page).to have_content post.article.content
     end

--- a/spec/system/visitor_views_post_spec.rb
+++ b/spec/system/visitor_views_post_spec.rb
@@ -22,12 +22,8 @@ RSpec.describe "Visitor views full posts", type: :system do
       category = create(:category)
       content = "It's important to me that you're happy. Maybe we got a few little happy bushes here, just covered with snow. It's all a game of angles. Anytime you learn something your time and energy are not wasted. You can do anything your heart can imagine. Do an almighty painting with us. We tell people sometimes: we're like drug dealers, come into town and get everybody absolutely addicted to painting. It doesn't take much to get you addicted. I guess that would be considered a UFO. A big cotton ball in the sky. Automatically, all of these beautiful, beautiful things will happen."
       article = create(:article, content: content)
-      tag = create(:tag)
 
-      post = create(:post,
-        categories: [category],
-        article: article,
-        tags: [tag])
+      post = create(:post_with_categories_and_tags, article: article, categories: [category])
 
       visit category_path(category)
 


### PR DESCRIPTION
In a previous commit, I introduced the `post_with_categories_and_tags`
factory.  This commit uses that factory, where applicable, to simplify
existing specs and make the code more legible.