### PR TITLE
Conditionalize Featured Post

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <h1><%= t(".title") %></h1>
 
 <% if post && post.featured? %>
-  <%= render "posts/featured", post: post %>
+  <%= render "posts/truncated", post: post %>
 <% end %>
 
 <ul>

--- a/app/views/posts/_featured.html.erb
+++ b/app/views/posts/_featured.html.erb
@@ -1,7 +1,0 @@
-<div>
-  <h2><%= post.title %></h2>
-  <p><%= t(".label") %></p>
-  <p><%= post.published_at %></p>
-  <p><%= post.content %></p>
-  <%= link_to t(".cta"), post_path(post) %>
-</div>

--- a/app/views/posts/_truncated.html.erb
+++ b/app/views/posts/_truncated.html.erb
@@ -1,5 +1,8 @@
 <div>
   <h2><%= link_to post.title, post_path(post) %></h2>
+  <% if post.featured? %>
+    <p><%= t("posts.featured_label") %></p>
+  <% end %>
   <p><%= post.published_at %></p>
   <p><%= truncate(post.content, length: 200, separator: ' ') { link_to t(".keep_reading"), post_path(post) }%></p>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= post.title %></h1>
 <% if post.featured? %>
-  <p><%= t("posts.featured.label") %></p>
+  <p><%= t("posts.featured_label") %></p>
 <% end %>
 <p><%= post.published_at %></p>
 <p><%= post.tags.map(&:name).join(", ") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,10 +40,8 @@ en:
     helpers:
       back: Back
   posts:
-    featured:
-      cta: "See full post >>"
-      label: "** Featured **"
+    featured_label: "** Featured **"
     show:
       back_to_category: "Back to %{category_name}"
     truncated:
-      keep_reading: " keep reading"
+      keep_reading: "keep reading"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
   end
 
   factory :post do
-    content { "This is an article for a blog post!" }
+    content { "Let your imagination be your guide. Clouds are free they come and go as they please. Isn't that fantastic? You can just push a little tree out of your brush like that. Look around, look at what we have. Beauty is everywhere, you only have to look to see it. Isn't it fantastic that you can change your mind and create all these happy things?" }
     image_url { "www.someimage.com" }
-    published_at { 1.month.from_now }
+    published_at { 1.month.ago }
     sequence(:title) { |n| "Blog Content ##{n}" }
 
     factory :post_with_categories_and_tags do

--- a/spec/system/visitor_views_blog_list_spec.rb
+++ b/spec/system/visitor_views_blog_list_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe "Visitor views blog list", type: :system do
         name: category.name
       )
 
-      expect(page).to have_content first_post.content
-      expect(page).to have_content second_post.content
+      expect(page).to have_content first_post.content.truncate(200, separator: " ") { link_to t("posts.truncated.keep_reading"), post_path(post) }
+      expect(page).to have_content second_post.content.truncate(200, separator: " ") { link_to t("posts.truncated.keep_reading"), post_path(post) }
     end
   end
 end

--- a/spec/system/visitor_views_featured_post_on_home_page_spec.rb
+++ b/spec/system/visitor_views_featured_post_on_home_page_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Visitor views featured post on home page", type: :system do
       visit root_path
 
       expect(page).to have_content featured_post.title
-      expect(page).to have_content I18n.t("posts.featured.label")
+      expect(page).to have_content I18n.t("posts.featured_label")
       expect(page).not_to have_content regular_post.title
     end
   end

--- a/spec/system/visitor_views_post_spec.rb
+++ b/spec/system/visitor_views_post_spec.rb
@@ -1,17 +1,16 @@
 require "rails_helper"
 
 RSpec.describe "Visitor views full posts", type: :system do
-  context "by clicking on 'see full post' link on home page" do
+  context "by clicking on CTA link on home page" do
     it "shows the full featured post" do
       post = create(:post_with_categories_and_tags, featured: true)
 
       visit root_path
-
-      click_on I18n.t("posts.featured.cta")
+      click_on I18n.t("posts.truncated.keep_reading")
 
       expect(page).to have_content post.title
       expect(page).to have_content post.published_at
-      expect(page).to have_content I18n.t("posts.featured.label")
+      expect(page).to have_content I18n.t("posts.featured_label")
       expect(page).to have_content post.tags.first.name
       expect(page).to have_content post.content
     end


### PR DESCRIPTION
## Problem
Currently there are three templates for posts: regular post, featured
post, and truncated post.  

## Solution 
This commit combines the featured and truncated posts since it is 
likely the design for those views will be the same.  To differentiate 
between them, a conditional on `featured` was added.  How we will 
indicate the featured status hasn't been decided yet.

The regular post was left as is as that design will be different from the
other two templates.

**_N.B._** It is possible that we would want to check if a post was
featured on the home page only, without signaling that state on a blog list.

